### PR TITLE
feat: project specific git hooks support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Check which files you have modified and launches the appropriate pre-commit hooks for that project
+
+TOUCHED_BACKEND=false
+
+for file in $(git status --porcelain | awk '($1 $2){print $2}'); do
+    if [[ ${file} =~ ^backend\/.*$ ]]; then
+        TOUCHED_BACKEND=true
+    fi
+done
+
+
+if ${TOUCHED_BACKEND}; then
+    .githooks/pre_commit_backend
+fi

--- a/.githooks/pre_commit_backend
+++ b/.githooks/pre_commit_backend
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "Running pre-commit hooks for project backend"
+cd backend
+
+make fmt


### PR DESCRIPTION
## Summary
Inside .githooks the pre-commit script launches before every commit.
It checks which files the user has changed and using regex matches
to different projects (e.g. backend). Then it launches the necessary
project specific git hook (e.g. pre_commit_backend).

Currently we only have a pre commit hook for the backend project.
We will introduce other pre commit hooks for other projects when
they will be required.