### PR TITLE
chore: explicity specify netlify auth and site flags

### DIFF
--- a/.github/workflows/website-main-pull-request.yml
+++ b/.github/workflows/website-main-pull-request.yml
@@ -41,11 +41,8 @@ jobs:
         run: "ls websites/main"  # TODO - build
       - name: Install Netlify CLI
         run: "sudo npm install netlify-cli -g"
-        # Removes a netlify-cli warning about not being able to ready a file in .config dir
-      - name: Permission .config
-        run: "sudo chown -R $USER:$(id -gn $USER) /home/runner/.config"
       - name: Netlify deploy
-        run: "netlify deploy --dir=./websites/main --json --message \"Deploy preview commit: ${GITHUB_SHA}\" | tee _netlify_deploy_response.txt"
+        run: "netlify deploy --auth ${NETLIFY_AUTH_TOKEN} --site ${NETLIFY_SITE_ID} --dir=./websites/main --json --message \"Deploy preview commit: ${GITHUB_SHA}\" | tee _netlify_deploy_response.txt"
         env:
           NETLIFY_SITE_ID: 9191587a-240f-43d6-9b25-f0ecc9be1fdf
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
<!-- 
    IMPORTANT: Please do not create a Pull Request without creating an issue first.

    Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.
 -->

## Summary
<!-- Describe your question and add as many details as possible -->
There is a bug with Netlify CLI that results in no new deploys. The error message is `Error: Unable to open browser automatically` which I think is masking the actual issue, which is authentication.