### PR TITLE
refactor(match-viewer): add argparse to serve_games_assets.py script

### DIFF
--- a/game-utils/match-viewer/README.md
+++ b/game-utils/match-viewer/README.md
@@ -1,5 +1,4 @@
 # Match Viewer
-
 A match viewer that can replay matches for Planet Lia games or any kind of 2D game.
 The only requirement is to store the match state in a replay file format documented in [How to Write Replay Files](#how-to-write-replay-files) guide.
 It is very simple, really flexible and it provides many cool features such as changing speed when playing a replay, jumping freely in time, displaying charts with statistics and much more.
@@ -7,17 +6,15 @@ It is very simple, really flexible and it provides many cool features such as ch
 ![Match Viewer](docs/images/match-viewer.png)
 
 ## How to Write Replay Files
-
 Are you developing your own game for Planet Lia or are you just interested in how it works?
 
 [CHECK THE GUIDE.](docs/writing_replay_files.md)
 
 ## Run
-
 1. `git clone REPO_URL`
 2. `cd games-utils/match-viewer/`
 3. `npm install`
-4. `python3 serve_games_assets.py ../../games/ 3333` 
+4. `python3 serve_games_assets.py ../../games/` 
     * This will serve assets from `games/` directory at port `3333` which is used in `src/App.tsx` file by default. 
     It will also allow CORS for easier development.
 5. `npm start`

--- a/game-utils/match-viewer/serve_games_assets.py
+++ b/game-utils/match-viewer/serve_games_assets.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python
-# Usage: python cors_http_server.py <dir> <port>
 
-import sys
+import argparse
 import os
-os.chdir(sys.argv[1])
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("dir", help="Root dir for the HTTP server", nargs=1)
+parser.add_argument("-p", "--port", type=int, help="Port to bind the HTTP server", required=False, default=3333)
+parser.add_argument("-b", "--bind", help="Bind address of HTTP server", required=False, default="127.0.0.1")
+cli_args = parser.parse_args()
+
+os.chdir(cli_args.dir[0])
 
 try:
     # try to use Python 3
     from http.server import HTTPServer, SimpleHTTPRequestHandler, test as test_orig
     def test (*args):
-        test_orig(*args, port=int(sys.argv[2]))
+        test_orig(*args, bind=cli_args.bind, port=cli_args.port)
 except ImportError: 
 	  # fall back to Python 2
     from BaseHTTPServer import HTTPServer, test
     from SimpleHTTPServer import SimpleHTTPRequestHandler
 
-class CORSRequestHandler (SimpleHTTPRequestHandler):
+class CORSRequestHandler(SimpleHTTPRequestHandler):
     def end_headers (self):
         self.send_header('Access-Control-Allow-Origin', '*')
         SimpleHTTPRequestHandler.end_headers(self)


### PR DESCRIPTION
<!-- 
    IMPORTANT: Please do not create a Pull Request without creating an issue first.

    Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.
 -->

## Summary
<!-- Describe your PR and add as many details as possible -->
<!-- How did you implement the solution? -->
<!-- Did you provide any tests? -->
Set default port to `3333` so that it is not necessary to add it to the arguments all the time, as well as bind to the localhost interface not all interfaces.

In case the user runs the script poorly (e.g. set the dir to `/`) they expose their entire filesystem to possibly the internet which would leek sensitive data. Binding to localhost (`127.0.0.1`) removes this vulnerability.
